### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,6 +32,8 @@ jobs:
     needs: doc_test
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jpartain89/Software-Install-Guides/security/code-scanning/1](https://github.com/jpartain89/Software-Install-Guides/security/code-scanning/1)

Add an explicit `permissions` block to `final_doc_creation` so the job does not rely on inherited defaults.  
Best minimal fix without changing behavior: grant only `contents: write` for `final_doc_creation`, since publishing to `gh-pages` requires pushing commits/branch updates.

Change region: `.github/workflows/documentation.yml`, inside `jobs.final_doc_creation`, directly under `runs-on` (or near other job keys), before `steps:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
